### PR TITLE
Transpose confound-corrected data matrix before returning it

### DIFF
--- a/neuroHarmonize/harmonizationLearn.py
+++ b/neuroHarmonize/harmonizationLearn.py
@@ -134,7 +134,7 @@ def harmonizationLearn(data, covars, eb=True, smooth_terms=[],
     bayes_data = bayes_data.T
     
     if return_s_data:
-        return model, bayes_data, s_data
+        return model, bayes_data, s_data.T
     else:
         return model, bayes_data
 


### PR DESCRIPTION
The outputs `bayes_data` and `s_data` of `harmonizationLearn()` represent the same kind of data, once with and once without correction of confounds. Thus, these should also have the same shape. This PR will transpose `s_data` to have the same shape as `bayes_data`.