### PR TITLE
Add details about the output to the docstring

### DIFF
--- a/neuroHarmonize/harmonizationLearn.py
+++ b/neuroHarmonize/harmonizationLearn.py
@@ -49,10 +49,12 @@ def harmonizationLearn(data, covars, eb=True, smooth_terms=[],
         gamma_hat, delta_hat, gamma_bar, t2, a_prior, b_prior, smooth_model
     
     bayes_data : a numpy array
-        harmonized data, dimensions are N_samples x N_features
-        
+        harmonized data, corrected for effects of SITE
+        dimensions are N_samples x N_features
+
     s_data (Optional) : a numpy array
-        if return_s_data=True
+        harmonized data, corrected for all covariates
+        set return_s_data=True to output the variable
     
     """
     # transpose data as per ComBat convention


### PR DESCRIPTION
This MR makes it more clear that the output variable `bayes_data` corrects for effects of `SITE` and `s_data` corrects for all covariates in the docstring of `harmonizationLearn()`.