### PR TITLE
fixing issue #35 to allow multiple smooth terms

### DIFF
--- a/neuroHarmonize/harmonizationLearn.py
+++ b/neuroHarmonize/harmonizationLearn.py
@@ -133,8 +133,11 @@ def harmonizationLearn(data, covars, eb=True, smooth_terms=[],
         # create cubic spline basis for smooth terms
         X_spline = covars[:, smooth_cols].astype(float)
         if orig_model is None:
-            bs = BSplines(X_spline, df=[10] * len(smooth_cols), degree=[3] * len(smooth_cols),
-                        knot_kwds=[{'lower_bound':smooth_term_bounds[0], 'upper_bound':smooth_term_bounds[1]}])
+            if len(smooth_cols)==1:
+                bs = BSplines(X_spline, df=10, degree=3,
+                            knot_kwds=[{'lower_bound':smooth_term_bounds[0], 'upper_bound':smooth_term_bounds[1]}])
+            else:
+                bs = BSplines(X_spline, df=[10] * len(smooth_cols), degree=[3] * len(smooth_cols))
             # construct formula and dataframe required for gam
             formula = 'y ~ '
             df_gam = {}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
 
 setup(name='neuroHarmonize',
-      version='2.3.0',
+      version='2.3.1',
       description='Harmonization tools for multi-center neuroimaging studies.',
       long_description=readme(),
       url='https://github.com/rpomponio/neuroHarmonize',


### PR DESCRIPTION
Addresses #35 by fixing the bug that prohibited multiple smooth terms. However, currently not supporting boundary knot control for multiple smooth terms (instead uses statsmodels defaults for [BSplines](https://www.statsmodels.org/dev/generated/statsmodels.gam.smooth_basis.BSplines.html)).